### PR TITLE
Feat/statemachine

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ is used to kill the old connection and force the client to initiate a new connec
 3.1 gRPC server enables reflection [GRPC Server Reflection Protocol](https://github.com/grpc/grpc/blob/master/doc/server-reflection.md#grpc-server-reflection-protocol)  (默认)<br/>
 3.2 provide local protobuf definition file
 ```
-./grpcr --input-raw="10.2.134.105:35001" --output-stdout --record-response --proto=./proto
+./grpcr --input-raw="0.0.0.0:35001" --output-stdout --record-response --proto=./proto
 ```
 `--proto` You can specify a file or folder. If it is a folder, all files with the suffix ".proto" will be loaded.
 4.  Only supports Unary RPC, not Streaming RPC

--- a/README_zh.md
+++ b/README_zh.md
@@ -58,7 +58,7 @@ make build
 3.1 gPRC服务端开启反射 [GRPC Server Reflection Protocol](https://github.com/grpc/grpc/blob/master/doc/server-reflection.md#grpc-server-reflection-protocol)  (默认)<br/>
 3.2 提供本地protobuf定义文件
 ```
-./grpcr --input-raw="10.2.134.105:35001" --output-stdout --record-response --proto=./proto
+./grpcr --input-raw="0.0.0.0:35001" --output-stdout --record-response --proto=./proto
 ```
 `--proto`可以指定文件或者文件夹，如果是文件夹，则后缀为“.proto”的文件都会被加载
 

--- a/config/settings.go
+++ b/config/settings.go
@@ -107,4 +107,7 @@ type AppSettings struct {
 	// file or directory
 	ProtoFileStr string `json:"proto"`
 	ProtoFiles   []string
+
+	// If the output has been processed, the maximum time to wait for the input to be processed
+	WaitDefaultDuration time.Duration
 }

--- a/example/search_server/server.go
+++ b/example/search_server/server.go
@@ -8,6 +8,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	_ "google.golang.org/grpc/encoding/gzip" // Registration of gzip Compressor will be completed
+	"google.golang.org/grpc/reflection"
 	"google.golang.org/grpc/status"
 	"log"
 	"net"
@@ -47,7 +48,7 @@ func main() {
 
 	// 注册反射服务
 	// Register reflection service on gRPC server.
-	//reflection.Register(server)
+	reflection.Register(server)
 	lis, err := net.Listen("tcp4", address)
 	if err != nil {
 		log.Fatalf("net.Listen err: %v", err)

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/shirou/gopsutil/v3 v3.24.5
+	github.com/smallnest/gofsm v0.0.0-20190306032117-f5ba1bddca7b
 	github.com/stretchr/testify v1.9.0
 	github.com/vearne/gtimer v0.0.0-20230826015705-eaf6bae03335
 	github.com/vearne/simplelog v0.0.2

--- a/go.sum
+++ b/go.sum
@@ -134,6 +134,8 @@ github.com/shirou/gopsutil/v3 v3.24.5/go.mod h1:bsoOS1aStSs9ErQ1WWfxllSeS1K5D+U3
 github.com/sirupsen/logrus v1.4.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2 h1:SPIRibHv4MatM3XXNO2BJeFLZwZ2LvZgfQ5+UNI2im4=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
+github.com/smallnest/gofsm v0.0.0-20190306032117-f5ba1bddca7b h1:uscpxZp8YYPynAdUOVxAPEk89pQZWzMJr1kVBTK/3ec=
+github.com/smallnest/gofsm v0.0.0-20190306032117-f5ba1bddca7b/go.mod h1:l0l2esXXKkA54ODLyzp7HPwpEYcDzjhJRnBLj/3/ZVs=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d h1:zE9ykElWQ6/NYmHa3jpm/yHnI4xSofP+UP6SpjHcSeM=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v1.6.4 h1:fv0U8FUIMPNf1L9lnHLvLhgicrIVChEkdzIKYqbNC9s=

--- a/http2/http2.go
+++ b/http2/http2.go
@@ -20,9 +20,12 @@ import (
 	"time"
 )
 
+var (
+	WaitDefaultDuration = 1 * time.Second
+)
+
 const (
-	PseudoHeaderPath    = ":path"
-	WaitDefaultDuration = 3 * time.Second
+	PseudoHeaderPath = ":path"
 )
 
 const (

--- a/http2/http2.go
+++ b/http2/http2.go
@@ -328,6 +328,7 @@ func (hc *Http2Conn) _processFrameData(f *FrameBase, item *HTTPItem) {
 				slog.Error("processFrameData, gunzip error:%v", err)
 				return
 			}
+			defer gzipReader.Close()
 			msg.EncodedMessage, err = io.ReadAll(gzipReader)
 			if err != nil {
 				slog.Error("processFrameData, gunzip error:%v", err)
@@ -495,7 +496,7 @@ func NewHTTPItem() *HTTPItem {
 	item.EndStream.Store(false)
 	item.EndHeader.Store(false)
 	item.Headers = &sync.Map{}
-	item.DataBuf = &util.GoroutineSafeBuffer{}
+	item.DataBuf = util.NewGoroutineSafeBuffer()
 	return &item
 }
 

--- a/http2/processor.go
+++ b/http2/processor.go
@@ -1,26 +1,31 @@
 package http2
 
 import (
+	fsm "github.com/smallnest/gofsm"
 	"github.com/vearne/grpcreplay/protocol"
 	slog "github.com/vearne/simplelog"
 	"math"
 )
 
 type Processor struct {
-	ConnRepository map[DirectConn]*Http2Conn
-	InputChan      chan *NetPkg
-	OutputChan     chan *protocol.Message
-	Finder         PBFinder
-	RecordResponse bool
+	ConnStates      map[DirectConn]*TCPConnectionState
+	ConnRepository  map[DirectConn]*Http2Conn
+	InputChan       chan *NetPkg
+	OutputChan      chan *protocol.Message
+	Finder          PBFinder
+	RecordResponse  bool
+	TCPStateMachine *fsm.StateMachine
 }
 
 func NewProcessor(input chan *NetPkg, recordResponse bool, finder PBFinder) *Processor {
 	var p Processor
+	p.ConnStates = make(map[DirectConn]*TCPConnectionState, 100)
 	p.ConnRepository = make(map[DirectConn]*Http2Conn, 100)
 	p.InputChan = input
 	p.OutputChan = make(chan *protocol.Message, 100)
 	p.Finder = finder
 	p.RecordResponse = recordResponse
+	p.TCPStateMachine = InitTCPFSM(&TCPEventProcessor{})
 	slog.Info("create new Processor")
 	return &p
 }
@@ -28,30 +33,17 @@ func NewProcessor(input chan *NetPkg, recordResponse bool, finder PBFinder) *Pro
 func (p *Processor) ProcessIncomingTCPPkg(pkg *NetPkg) {
 	dc := pkg.DirectConn()
 	payload := pkg.TCP.Payload
-	slog.Debug("Connection:%v, seq:%v, length:%v", dc.String(), pkg.TCP.Seq, len(payload))
 
 	if _, ok := p.ConnRepository[dc]; !ok {
-		p.ConnRepository[dc] = NewHttp2Conn(dc, http2initialHeaderTableSize, p)
-	}
-	hc := p.ConnRepository[dc]
-
-	payloadSize := uint32(len(payload))
-
-	// SYN/ACK/FIN
-	if len(payload) <= 0 {
-		if pkg.TCP.FIN {
-			slog.Info("got Fin package, close connection:%v", dc.String())
-			hc.Input.TCPBuffer.Close()
-			delete(p.ConnRepository, dc)
-		} else {
-			hc.Input.TCPBuffer.expectedSeq = (pkg.TCP.Seq + payloadSize) % math.MaxUint32
-		}
 		return
 	}
 
+	hc := p.ConnRepository[dc]
+	payloadSize := uint32(len(payload))
+
 	// connection preface
 	if IsConnPreface(payload) {
-		hc.Input.TCPBuffer.expectedSeq = (pkg.TCP.Seq + payloadSize) % math.MaxUint32
+		hc.Input.TCPBuffer.SetExpectedSeq((pkg.TCP.Seq + payloadSize) % math.MaxUint32)
 		return
 	}
 
@@ -70,34 +62,55 @@ func (p *Processor) ProcessOutComingTCPPkg(pkg *NetPkg) {
 	}
 
 	hc := p.ConnRepository[rDirect]
-	payloadSize := uint32(len(payload))
-
-	// SYN/ACK/FIN
-	if len(payload) <= 0 {
-		if pkg.TCP.FIN {
-			slog.Info("got Fin package, close connection:%v", rDirect.String())
-			hc.Output.TCPBuffer.Close()
-			delete(p.ConnRepository, rDirect)
-		} else {
-			hc.Output.TCPBuffer.expectedSeq = (pkg.TCP.Seq + payloadSize) % math.MaxUint32
-		}
-		return
-	}
-
 	slog.Debug("[AddTCP]Connection:%v, seq:%v, length:%v", dc.String(), pkg.TCP.Seq, len(payload))
 	hc.Output.TCPBuffer.AddTCP(pkg.TCP)
-
 }
 
 func (p *Processor) ProcessTCPPkg() {
 	// need to handle both inbound and outbound traffic
 	for pkg := range p.InputChan {
-		if pkg.Direction == DirIncoming {
-			p.ProcessIncomingTCPPkg(pkg)
-		} else if p.RecordResponse && pkg.Direction == DirOutcoming {
-			p.ProcessOutComingTCPPkg(pkg)
+		payload := pkg.TCP.Payload
+		dc := pkg.DirectConn()
+		slog.Debug("Connection:%v, seq:%v, length:%v", dc.String(), pkg.TCP.Seq, len(payload))
+
+		if pkg.Direction == DirOutcoming {
+			dc = dc.Reverse()
 		}
+		ts, exist := p.ConnStates[dc]
+		if !exist {
+			p.ConnStates[dc] = NewTCPConnection(dc)
+			ts = p.ConnStates[dc]
+		}
+		// try to handling connection status
+		err := p.handleConnectionState(ts, pkg)
+		if err != nil {
+			slog.Warn("TCPStateMachine.Trigger, %v", err)
+		}
+
+		// data
+		if ts.State == StateEstablished && len(payload) > 0 {
+			if pkg.Direction == DirIncoming {
+				p.ProcessIncomingTCPPkg(pkg)
+			} else if p.RecordResponse && pkg.Direction == DirOutcoming {
+				p.ProcessOutComingTCPPkg(pkg)
+			}
+		}
+
 	}
+}
+
+func (p *Processor) handleConnectionState(ts *TCPConnectionState, pkg *NetPkg) error {
+	if len(pkg.TCP.Payload) > 0 {
+		return nil
+	}
+	if pkg.Direction == DirIncoming && pkg.TCP.SYN {
+		return p.TCPStateMachine.Trigger(ts.State, EventReceiveSYN, ts, pkg, p)
+	} else if pkg.Direction == DirOutcoming && pkg.TCP.SYN && pkg.TCP.ACK {
+		return p.TCPStateMachine.Trigger(ts.State, EventSendSYNACK, ts, pkg, p)
+	} else if pkg.Direction == DirIncoming && pkg.TCP.ACK {
+		return p.TCPStateMachine.Trigger(ts.State, EventReceiveACK, ts, pkg, p)
+	}
+	return nil
 }
 
 func IsConnPreface(payload []byte) bool {

--- a/http2/state_machine.go
+++ b/http2/state_machine.go
@@ -1,0 +1,90 @@
+package http2
+
+import (
+	"github.com/smallnest/gofsm"
+	"log/slog"
+)
+
+const (
+	StateListen = "LISTEN"
+	// receive SYN
+	StateSynReceived1 = "SYN-RECEIVED-1"
+	// receive SYN and send SYN+ACK
+	StateSynReceived2 = "SYN-RECEIVED-2"
+	// receive ACK
+	StateEstablished = "ESTABLISHED"
+)
+const (
+	EventReceiveSYN = "RECEIVE_SYN"
+	EventReceiveACK = "RECEIVE_ACK"
+	EventSendSYNACK = "SEND_SYN_ACK"
+)
+
+type TCPConnectionState struct {
+	dc     DirectConn
+	State  string
+	States []string
+}
+
+func NewTCPConnection(dc DirectConn) *TCPConnectionState {
+	var t TCPConnectionState
+	t.dc = dc
+	t.State = StateListen
+	t.States = []string{StateListen}
+	return &t
+}
+
+type TCPEventProcessor struct{}
+
+func (p *TCPEventProcessor) Action(action string, fromState string, toState string, args []interface{}) error {
+	ts := args[0].(*TCPConnectionState)
+	switch action {
+	case "change-state":
+		slog.Debug("change-state, DirectConn:%v, fromState:[%v] -> toState:[%v]\n", ts.dc.String(), fromState, toState)
+	case "do-nothing":
+		slog.Debug("do-nothing, DirectConn:%v, current state:%v\n", ts.dc.String(), toState)
+	case "establish-connection":
+		slog.Debug("establish-connection, DirectConn:%v", ts.dc.String())
+	default:
+		slog.Debug("unknow action: %v\n, DirectConn:%v", action, ts.dc.String())
+	}
+	return nil
+}
+
+func (p *TCPEventProcessor) OnActionFailure(action string, fromState string, toState string, args []interface{}, err error) {
+
+}
+
+func (p *TCPEventProcessor) OnExit(fromState string, args []interface{}) {
+}
+
+func (p *TCPEventProcessor) OnEnter(toState string, args []interface{}) {
+	ts := args[0].(*TCPConnectionState)
+	ts.State = toState
+	ts.States = append(ts.States, toState)
+	slog.Debug("OnEnter, DirectConn:%v, connection state -> %v\n", ts.dc.String(), toState)
+	// args []interface{}
+	// ts *TCPConnectionState, pkg *NetPkg, p *Processor
+	if ts.State == StateEstablished {
+		p := args[2].(*Processor)
+		p.ConnRepository[ts.dc] = NewHttp2Conn(ts.dc, http2initialHeaderTableSize, p)
+		slog.Info("TCPEventProcessor connection [ESTABLISHED], DirectConn:%v", ts.dc.String())
+	}
+}
+
+func InitTCPFSM(processor fsm.EventProcessor) *fsm.StateMachine {
+	delegate := &fsm.DefaultDelegate{P: processor}
+
+	// from the server's perspective
+	transitions := []fsm.Transition{
+		// Split SYN-RECEIVED into two states: SYN-RECEIVED-1 and SYN-RECEIVED-2
+		{From: StateListen, Event: EventReceiveSYN, To: StateSynReceived1, Action: "change-state"},
+		{From: StateSynReceived1, Event: EventReceiveSYN, To: StateSynReceived1, Action: "do-nothing"},
+		{From: StateSynReceived1, Event: EventSendSYNACK, To: StateSynReceived2, Action: "change-state"},
+		{From: StateSynReceived2, Event: EventSendSYNACK, To: StateSynReceived2, Action: "do-nothing"},
+		{From: StateSynReceived2, Event: EventReceiveACK, To: StateEstablished, Action: "establish-connection"},
+		{From: StateEstablished, Event: EventReceiveACK, To: StateEstablished, Action: "do-nothing"},
+	}
+
+	return fsm.NewStateMachine(delegate, transitions...)
+}

--- a/http2/state_machine.go
+++ b/http2/state_machine.go
@@ -78,7 +78,8 @@ func (p *TCPEventProcessor) OnEnter(toState string, args []interface{}) {
 	slog.Debug("OnEnter, DirectConn:%v, connection state -> %v", ts.dc.String(), toState)
 	// args []interface{}
 	// ts *TCPConnectionState, pkg *NetPkg, p *Processor
-	if ts.State == StateEstablished {
+	switch ts.State {
+	case StateEstablished:
 		p := args[2].(*Processor)
 		hc := NewHttp2Conn(ts.dc, http2initialHeaderTableSize, p)
 		p.ConnRepository[ts.dc] = hc
@@ -93,7 +94,7 @@ func (p *TCPEventProcessor) OnEnter(toState string, args []interface{}) {
 		hc.Output.TCPBuffer.SetExpectedSeq(pkg.TCP.Ack)
 
 		slog.Info("TCPEventProcessor connection [ESTABLISHED], DirectConn:%v", ts.dc.String())
-	} else if ts.State == StateClosed {
+	case StateClosed:
 		p := args[2].(*Processor)
 		delete(p.ConnStates, ts.dc)
 		delete(p.ConnRepository, ts.dc)

--- a/http2/state_machine.go
+++ b/http2/state_machine.go
@@ -95,6 +95,7 @@ func (p *TCPEventProcessor) OnEnter(toState string, args []interface{}) {
 		slog.Info("TCPEventProcessor connection [ESTABLISHED], DirectConn:%v", ts.dc.String())
 	} else if ts.State == StateClosed {
 		p := args[2].(*Processor)
+		delete(p.ConnStates, ts.dc)
 		delete(p.ConnRepository, ts.dc)
 		slog.Info("TCPEventProcessor connection [CLOSED], DirectConn:%v", ts.dc.String())
 	}
@@ -125,6 +126,7 @@ func InitTCPFSM(processor fsm.EventProcessor) *fsm.StateMachine {
 
 		// 3.
 		{From: StateEstablished, Event: EventReceiveRST, To: StateClosed, Action: "change-state"},
+		{From: StateListen, Event: EventReceiveRST, To: StateClosed, Action: "change-state"},
 	}
 
 	return fsm.NewStateMachine(delegate, transitions...)

--- a/http2/state_machine_test.go
+++ b/http2/state_machine_test.go
@@ -1,0 +1,65 @@
+package http2
+
+import (
+	"log"
+	"testing"
+)
+
+type TestEventProcessor struct{}
+
+func (p *TestEventProcessor) Action(action string, fromState string, toState string, args []interface{}) error {
+	switch action {
+	case "change-state":
+		log.Printf("change-state, fromState:[%v] -> toState:[%v]\n", fromState, toState)
+	case "do-nothing":
+		log.Printf("do-nothing, current state:%v\n", toState)
+	case "establish-connection":
+		log.Printf("establish-connection")
+	default:
+		log.Printf("unknow action: %v\n", action)
+	}
+	return nil
+}
+
+func (p *TestEventProcessor) OnActionFailure(action string, fromState string, toState string, args []interface{}, err error) {
+
+}
+
+func (p *TestEventProcessor) OnExit(fromState string, args []interface{}) {
+}
+
+func (p *TestEventProcessor) OnEnter(toState string, args []interface{}) {
+	log.Printf("OnEnter, connection state -> %v\n", toState)
+	ts := args[0].(*TCPConnectionState)
+	ts.State = toState
+	ts.States = append(ts.States, toState)
+}
+
+func TestTCPFSM(t *testing.T) {
+	ts := &TCPConnectionState{
+		State:  StateListen,
+		States: []string{StateListen},
+	}
+	tcpFSM := InitTCPFSM(&TestEventProcessor{})
+
+	var err error
+	err = tcpFSM.Trigger(ts.State, EventReceiveSYN, ts)
+	if err != nil {
+		t.Errorf("trigger err: %v", err)
+	}
+
+	err = tcpFSM.Trigger(ts.State, EventSendSYNACK, ts)
+	if err != nil {
+		t.Errorf("trigger err: %v", err)
+	}
+
+	err = tcpFSM.Trigger(ts.State, EventReceiveACK, ts)
+	if err != nil {
+		t.Errorf("trigger err: %v", err)
+	}
+
+	t.Logf("current state:%v", ts.State)
+	if ts.State != StateEstablished {
+		t.Errorf("expect:%v, actual:%v", StateEstablished, ts.State)
+	}
+}

--- a/http2/tcp_buffer.go
+++ b/http2/tcp_buffer.go
@@ -86,7 +86,7 @@ func (sb *TCPBuffer) AddTCP(tcpPkg *layers.TCP) {
 
 	// Discard packets outside the sliding window
 	if !validPackage(sb.expectedSeq, MaxWindowSize, tcpPkg.Seq) {
-		slog.Debug("[end]SocketBuffer.addTCP-discard packets outside the sliding window, "+
+		slog.Warn("[end]SocketBuffer.addTCP-discard packets outside the sliding window, "+
 			"size:%v, actualCanReadSize:%v, expectedSeq:%v",
 			sb.size.Load(), sb.actualCanReadSize.Load(), sb.expectedSeq)
 		return
@@ -94,7 +94,7 @@ func (sb *TCPBuffer) AddTCP(tcpPkg *layers.TCP) {
 
 	// duplicate package
 	if sb.List.Get(tcpPkg.Seq) != nil {
-		slog.Debug("[end]SocketBuffer.addTCP-duplicate package, size:%v, actualCanReadSize:%v, expectedSeq:%v",
+		slog.Warn("[end]SocketBuffer.addTCP-duplicate package, size:%v, actualCanReadSize:%v, expectedSeq:%v",
 			sb.size.Load(), sb.actualCanReadSize.Load(), sb.expectedSeq)
 		return
 	}

--- a/http2/tcp_buffer.go
+++ b/http2/tcp_buffer.go
@@ -36,6 +36,10 @@ func NewTCPBuffer() *TCPBuffer {
 	return &sb
 }
 
+func (sb *TCPBuffer) SetExpectedSeq(expectedSeq uint32) {
+	sb.expectedSeq = expectedSeq
+}
+
 func (sb *TCPBuffer) Close() {
 	close(sb.closeChan)
 }

--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	"github.com/vearne/grpcreplay/biz"
 	"github.com/vearne/grpcreplay/config"
 	"github.com/vearne/grpcreplay/consts"
+	"github.com/vearne/grpcreplay/http2"
 	"github.com/vearne/grpcreplay/util"
 	slog "github.com/vearne/simplelog"
 	"os"
@@ -123,6 +124,11 @@ func init() {
 
 	flag.StringVar(&settings.ProtoFileStr, "proto", "",
 		"(optional) proto source file or the directory containing the proto file.")
+
+	flag.DurationVar(&settings.WaitDefaultDuration, "wait-timeout", time.Second,
+		`If the output has been processed, the maximum time to wait for the input to be processed
+				--wait-timeout=3s			
+	`)
 }
 
 func main() {
@@ -205,6 +211,8 @@ func parseSettings(settings *config.AppSettings) {
 	} else {
 		settings.ProtoFiles = []string{settings.ProtoFileStr}
 	}
+
+	http2.WaitDefaultDuration = settings.WaitDefaultDuration
 }
 
 func printSettings(settings *config.AppSettings) {
@@ -227,4 +235,6 @@ func printSettings(settings *config.AppSettings) {
 		slog.Info("ProtoFileStr, %v", settings.ProtoFileStr)
 		slog.Info("ProtoFiles, %v", settings.ProtoFiles)
 	}
+
+	slog.Info("wait-timeout, %v", settings.WaitDefaultDuration)
 }

--- a/plugin/input_raw.go
+++ b/plugin/input_raw.go
@@ -67,33 +67,42 @@ func (l *DeviceListener) listen() error {
 		conn := netPkg.DirectConn()
 		slog.Debug("DeviceListener.listen-connection:%v, Direction:%v",
 			&conn, http2.GetDirection(netPkg.Direction))
-		if netPkg.Direction == http2.DirIncoming {
-			if l.rawInput.connSet.Has(conn) { // history connection
-				if netPkg.TCP.ACK && netPkg.IPv4 != nil {
-					slog.Debug("receive Ack package, for connection:%v, expected seq:%v, window:%v",
-						&conn, netPkg.TCP.Ack, netPkg.TCP.Window)
-					actualSeq := netPkg.TCP.Ack
+		// Handle packet based on direction
+		switch netPkg.Direction {
+		case http2.DirIncoming:
+			if l.rawInput.connSet.Has(conn) {
+				switch {
+				case netPkg.TCP.ACK && netPkg.IPv4 != nil:
+					// Batch RST calculations to avoid repeated window calculations
+					window := uint32(netPkg.TCP.Window)
+					baseSeq := netPkg.TCP.Ack
 					for i := 0; i < RSTNum; i++ {
-						actualSeq += uint32(netPkg.TCP.Window) * uint32(i)
-						slog.Debug("send RST, for connection:%v, seq:%v", &conn, actualSeq)
-						// forge a packet from local -> remote
-						err = SendRST(netPkg.Ethernet.DstMAC, netPkg.Ethernet.SrcMAC,
-							netPkg.IPv4.DstIP, netPkg.IPv4.SrcIP, netPkg.TCP.DstPort,
-							netPkg.TCP.SrcPort, actualSeq, l.handle)
-						if err != nil {
-							slog.Error("SendRST, for connection:%v, error:%v", &conn, err)
+						seq := baseSeq + window*uint32(i)
+						slog.Debug("send RST", "connection", &conn, "seq", seq)
+						if err := SendRST(
+							netPkg.Ethernet.DstMAC,
+							netPkg.Ethernet.SrcMAC,
+							netPkg.IPv4.DstIP,
+							netPkg.IPv4.SrcIP,
+							netPkg.TCP.DstPort,
+							netPkg.TCP.SrcPort,
+							seq,
+							l.handle,
+						); err != nil {
+							slog.Error("SendRST failed", "connection", &conn, "error", err)
 						}
 					}
-				} else if netPkg.TCP.SYN { // // new connection
-					slog.Debug("got SYN, remove %v from connSet", &conn)
+				case netPkg.TCP.SYN:
+					slog.Debug("got SYN", "connection", &conn)
 					l.rawInput.connSet.Remove(conn)
 				}
-			} else { // new connection
+			} else {
 				l.rawInput.outputChan <- netPkg
 			}
-		} else if netPkg.Direction == http2.DirOutcoming {
+		case http2.DirOutcoming:
 			l.rawInput.outputChan <- netPkg
 		}
+
 	}
 	return nil
 }

--- a/plugin/input_raw.go
+++ b/plugin/input_raw.go
@@ -91,7 +91,7 @@ func (l *DeviceListener) listen() error {
 			} else { // new connection
 				l.rawInput.outputChan <- netPkg
 			}
-		} else if l.rawInput.recordResponse && netPkg.Direction == http2.DirOutcoming {
+		} else if netPkg.Direction == http2.DirOutcoming {
 			l.rawInput.outputChan <- netPkg
 		}
 	}

--- a/test/state_machine/main.go
+++ b/test/state_machine/main.go
@@ -1,0 +1,151 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	fsm "github.com/smallnest/gofsm"
+	"log"
+)
+
+type Turnstile struct {
+	ID         uint64
+	EventCount uint64
+	CoinCount  uint64
+	PassCount  uint64
+	State      string
+	States     []string
+}
+
+// TurnstileEventProcessor is used to handle turnstile actions.
+type TurnstileEventProcessor struct{}
+
+func (p *TurnstileEventProcessor) OnExit(fromState string, args []interface{}) {
+	t := args[0].(*Turnstile)
+	if t.State != fromState {
+		panic(fmt.Errorf("转门 %v 的状态与期望的状态 %s 不一致，可能在状态机外被改变了", t, fromState))
+	}
+
+	log.Printf("转门 %d 从状态 %s 改变", t.ID, fromState)
+}
+
+func (p *TurnstileEventProcessor) Action(action string, fromState string, toState string, args []interface{}) error {
+	t := args[0].(*Turnstile)
+	t.EventCount++
+
+	switch action {
+	case "pass": //用户通过的action
+		t.PassCount++
+	case "check", "repeat-check": //刷卡或者投币的action
+		if t.CoinCount > 0 { // repeat-check
+			return errors.New("转门暂时故障")
+		}
+		t.CoinCount++
+	case "invalid-push":
+		log.Println("invalid-push")
+	default: //其它action
+	}
+
+	return nil
+}
+
+func (p *TurnstileEventProcessor) OnEnter(toState string, args []interface{}) {
+	t := args[0].(*Turnstile)
+	t.State = toState
+	t.States = append(t.States, toState)
+
+	log.Printf("转门 %d 的状态改变为 %s ", t.ID, toState)
+}
+
+func (p *TurnstileEventProcessor) OnActionFailure(action string, fromState string, toState string, args []interface{}, err error) {
+	t := args[0].(*Turnstile)
+
+	log.Printf("转门 %d 的状态从 %s to %s 改变失败， 原因: %v", t.ID, fromState, toState, err)
+}
+
+func main() {
+	ts := &Turnstile{
+		ID:     1,
+		State:  "Locked",
+		States: []string{"Locked"},
+	}
+	myfsm := initFSM()
+
+	//推门
+	//没刷卡/投币不可进入
+	err := myfsm.Trigger(ts.State, "Push", ts)
+	if err != nil {
+		log.Printf("trigger err: %v\n", err)
+	}
+
+	//推门
+	//没刷卡/投币不可进入
+	err = myfsm.Trigger(ts.State, "Push", ts)
+	if err != nil {
+		log.Printf("trigger err: %v\n", err)
+	}
+
+	//刷卡或者投币
+	//不容易啊，终于解锁了
+	err = myfsm.Trigger(ts.State, "Coin", ts)
+	if err != nil {
+		log.Printf("trigger err: %v\n", err)
+	}
+
+	//刷卡或者投币
+	//无用的投币, 测试Action执行失败
+	err = myfsm.Trigger(ts.State, "Coin", ts)
+	if err != nil {
+		log.Printf("trigger err: %v\n", err)
+	}
+
+	//推门
+	//这时才能进入，进入后闸门被锁
+	err = myfsm.Trigger(ts.State, "Push", ts)
+	if err != nil {
+		log.Printf("trigger err: %v\n", err)
+	}
+
+	//推门
+	//无法进入，闸门已锁
+	err = myfsm.Trigger(ts.State, "Push", ts)
+	if err != nil {
+		log.Printf("trigger err: %v\n", err)
+	}
+
+	lastState := Turnstile{
+		ID:         1,
+		EventCount: 6,
+		CoinCount:  1,
+		PassCount:  1,
+		State:      "Locked",
+		States:     []string{"Locked", "Unlocked", "Locked"},
+	}
+
+	if !compareTurnstile(&lastState, ts) {
+		log.Printf("Expected last state: %+v, but got %+v\n", lastState, ts)
+	} else {
+		log.Printf("最终的状态: %+v\n", ts)
+	}
+}
+
+func compareTurnstile(t1 *Turnstile, t2 *Turnstile) bool {
+	if t1.ID != t2.ID || t1.CoinCount != t2.CoinCount || t1.EventCount != t2.EventCount || t1.PassCount != t2.PassCount ||
+		t1.State != t2.State {
+		return false
+	}
+
+	return fmt.Sprint(t1.States) == fmt.Sprint(t2.States)
+}
+
+func initFSM() *fsm.StateMachine {
+	delegate := &fsm.DefaultDelegate{P: &TurnstileEventProcessor{}}
+
+	transitions := []fsm.Transition{
+		{From: "Locked", Event: "Coin", To: "Unlocked", Action: "check"},
+		{From: "Locked", Event: "Push", To: "Locked", Action: "invalid-push"},
+		{From: "Unlocked", Event: "Push", To: "Locked", Action: "pass"},
+		{From: "Unlocked", Event: "Coin", To: "Unlocked", Action: "repeat-check"},
+	}
+
+	return fsm.NewStateMachine(delegate, transitions...)
+}

--- a/util/goroutine_safe_buffer.go
+++ b/util/goroutine_safe_buffer.go
@@ -7,7 +7,13 @@ import (
 
 type GoroutineSafeBuffer struct {
 	mu  sync.Mutex
-	buf bytes.Buffer
+	buf *bytes.Buffer
+}
+
+func NewGoroutineSafeBuffer() *GoroutineSafeBuffer {
+	var b GoroutineSafeBuffer
+	b.buf = bytes.NewBuffer([]byte{})
+	return &b
 }
 
 func (g *GoroutineSafeBuffer) Write(p []byte) (n int, err error) {

--- a/util/util.go
+++ b/util/util.go
@@ -1,6 +1,7 @@
 package util
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -8,6 +9,10 @@ import (
 )
 
 func ListFilesRecursively(dir string, set *StringSet) error {
+	if set == nil {
+		return errors.New("StringSet cannot be nil")
+	}
+	dir = filepath.Clean(dir)
 	d, err := os.Open(dir)
 	if err != nil {
 		return fmt.Errorf("can't open %s: %v", dir, err)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a command-line flag to set the maximum wait time for input processing after output.
  - Introduced a TCP connection state machine for more accurate connection lifecycle management.
  - Enabled gRPC server reflection in the example server.
- **Bug Fixes**
  - Improved error handling in file listing to prevent nil pointer dereference.
- **Refactor**
  - Unified protobuf descriptor finding logic into a single delegate type.
  - Switched internal buffer initialization to use a dedicated constructor.
  - Reorganized TCP packet processing to respect connection states.
- **Documentation**
  - Updated example commands in both English and Chinese README files with a generic IP address.
- **Style**
  - Increased log severity for certain TCP buffer warnings.
- **Tests**
  - Added tests for the new TCP state machine and a sample FSM (finite state machine) implementation.
- **Chores**
  - Added a new dependency for FSM (finite state machine) support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->